### PR TITLE
Added RequestOptions 

### DIFF
--- a/api.go
+++ b/api.go
@@ -202,9 +202,9 @@ func (client *Client) FindSimilar(ctx context.Context, url string, options ...Cl
 // - *ContentsResponse: The contents response object.
 // - error: An error if the contents retrieval fails.
 func (client *Client) GetContents(ctx context.Context, ids []string) (*ContentsResponse, error) {
-	client.loadOptions()
-
 	contentsResults := &ContentsResponse{}
+	
+	client.loadOptions()
 
 	joinedIds := strings.Join(ids, "\",\"")
 
@@ -219,7 +219,7 @@ func (client *Client) GetContents(ctx context.Context, ids []string) (*ContentsR
 
 	responseBody, err := client.runRequest(req)
 	if err != nil {
-		return &ContentsResponse{}, fmt.Errorf("%w: %w", ErrGetContentsFailed, err)
+		return contentsResults, fmt.Errorf("%w: %w", ErrGetContentsFailed, err)
 	}
 
 	err = json.Unmarshal(responseBody, &contentsResults)

--- a/api_options.go
+++ b/api_options.go
@@ -1,5 +1,17 @@
 package metaphor
 
+type RequestOptions struct {
+	NumResults         int      `json:"numResults,omitempty"`
+	IncludeDomains     []string `json:"includeDomains,omitempty"`
+	ExcludeDomains     []string `json:"excludeDomains,omitempty"`
+	StartCrawlDate     string   `json:"startCrawlDate,omitempty"`
+	EndCrawlDate       string   `json:"endCrawlDate,omitempty"`
+	StartPublishedDate string   `json:"startPublishedDate,omitempty"`
+	EndPublishedDate   string   `json:"endPublishedDate,omitempty"`
+	UseAutoprompt      bool     `json:"useAutoprompt,omitempty"`
+	Type               string   `json:"type,omitempty"`
+}
+
 type ClientOptions func(*Client)
 
 // WithNumResults sets the number of expected search results.
@@ -141,5 +153,50 @@ func WithType(searchType string) ClientOptions {
 func WithBaseURL(baseURL string) ClientOptions {
 	return func(client *Client) {
 		client.BaseURL = baseURL
+	}
+}
+
+// WithRequestOptions sets the request options for the client.
+//
+// Parameters:
+// - reqOptions: The request options to be set of RequestOptions type.
+// Returns: a ClientOptions function that updates the RequestBody with additional options.
+func WithRequestOptions(reqOptions *RequestOptions) ClientOptions {
+	return func(client *Client) {
+		if reqOptions.EndCrawlDate != "" {
+			client.RequestBody.EndCrawlDate = reqOptions.EndCrawlDate
+		}
+
+		if reqOptions.EndPublishedDate != "" {
+			client.RequestBody.EndPublishedDate = reqOptions.EndPublishedDate
+		}
+
+		if reqOptions.StartCrawlDate != "" {
+			client.RequestBody.StartCrawlDate = reqOptions.StartCrawlDate
+		}
+
+		if reqOptions.StartPublishedDate != "" {
+			client.RequestBody.StartPublishedDate = reqOptions.StartPublishedDate
+		}
+
+		if reqOptions.UseAutoprompt {
+			client.RequestBody.UseAutoprompt = reqOptions.UseAutoprompt
+		}
+
+		if reqOptions.Type != "" {
+			client.RequestBody.Type = reqOptions.Type
+		}
+
+		if reqOptions.NumResults != 0 {
+			client.RequestBody.NumResults = reqOptions.NumResults
+		}
+
+		if reqOptions.ExcludeDomains != nil {
+			client.RequestBody.ExcludeDomains = reqOptions.ExcludeDomains
+		}
+
+		if reqOptions.IncludeDomains != nil {
+			client.RequestBody.IncludeDomains = reqOptions.IncludeDomains
+		}
 	}
 }

--- a/examples/specific_search/main.go
+++ b/examples/specific_search/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/metaphorsystems/metaphor-go"
+)
+
+func main() {
+
+	apiKey := os.Getenv("METAPHOR_API_KEY")
+
+	client, err := metaphor.NewClient(apiKey)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	searchQuery := "Who is RDJ?"
+	ctx := context.Background()
+
+	// 
+	// Here we can use RequestOptions to customize the search.
+	//
+	reqOptions := metaphor.RequestOptions {
+		StartCrawlDate: "2023-01-01",
+		EndCrawlDate: "2023-12-32",
+		ExcludeDomains: []string{"www.wikipedia.com"},
+	}
+	
+	//
+	// reqOption can be combined with ClientOptions to build the final search request.
+	// If the same filed is present in both ClientOptions and RequestOptions, 
+	// the last one set will be used.
+	// in this example, we are setting UseAutoprompt to true.
+	// but if we set in reqOptions, it will override the value set in ClientOptions.
+	searchResults, err := client.Search(
+		ctx, 
+		searchQuery, 
+		metaphor.WithAutoprompt(true),
+		metaphor.WithRequestOptions(&reqOptions),
+	)
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	resultContents, err := searchResults.GetContents(ctx, client)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	
+	formatResults(resultContents)
+}
+
+func formatResults(response *metaphor.ContentsResponse) {
+	formattedResults := ""
+
+	for _, result := range response.Contents {
+		formattedResults += fmt.Sprintf("Title: %s\nURL: %s\nID: %s\n Content: %s\n\n", result.Title, result.URL, result.ID, result.Extract)
+	}
+
+	println(formattedResults)
+}


### PR DESCRIPTION
Added the option to pass a single RequestObject as one of the options function. This allows to set the req options in more dynamic way, ie. from a json, or other sources. 

Useage: 

```go
        apiKey := os.Getenv("METAPHOR_API_KEY")

	client, err := metaphor.NewClient(apiKey)
	if err != nil {
		fmt.Println(err)
		return
	}

	searchQuery := "Who is RDJ?"
	ctx := context.Background()

	// 
	// Here we can use RequestOptions to customize the search.
	//
	reqOptions := metaphor.RequestOptions {
		StartCrawlDate: "2023-01-01",
		EndCrawlDate: "2023-12-32",
		ExcludeDomains: []string{"www.wikipedia.com"},
	}
	
	//
	// reqOption can be combined with ClientOptions to build the final search request.
	// If the same field is present in both ClientOptions and RequestOptions, 
	// the last one set will be used.
	// in this example, we are setting UseAutoprompt to true.
	// but if we set in reqOptions,
        //
	// reqOptions.UseAutoprompt = true
	// 
        // it will override the value set via ClientOptions function.
	searchResults, err := client.Search(
		ctx, 
		searchQuery, 
		metaphor.WithAutoprompt(true),
		metaphor.WithRequestOptions(&reqOptions),
	)

	if err != nil {
		fmt.Println(err)
		return
	}

	resultContents, err := searchResults.GetContents(ctx, client)
	if err != nil {
		fmt.Println(err)
		return
	}
```